### PR TITLE
security: add permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend (lint + test)


### PR DESCRIPTION
## Summary
- Add explicit permissions blocks to workflow files missing them
- Follows principle of least privilege
- Resolves GitHub Code Security "Workflow does not contain permissions" alerts

## Test plan
- [ ] CI passes on this PR

Generated with Claude Code