### PR TITLE
docs: document all 46 API endpoints, add Apache-2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Ray Ketcham
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![SQLite](https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white)
 ![Tests](https://img.shields.io/badge/tests-252%20passing-brightgreen)
 ![Endpoints](https://img.shields.io/badge/API%20endpoints-46-blue)
+![License](https://img.shields.io/badge/license-Apache--2.0-green)
 
 # gh-tracker
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <div align="center">
 
 [![CI](https://github.com/rayketcham-lab/gh-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/rayketcham-lab/gh-tracker/actions/workflows/ci.yml)
-![Python 3.12](https://img.shields.io/badge/python-3.12-3776AB?logo=python&logoColor=white)
+![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)
 ![React 18](https://img.shields.io/badge/react-18-61DAFB?logo=react&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white)
-![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-252%20passing-brightgreen)
 ![Endpoints](https://img.shields.io/badge/API%20endpoints-46-blue)
 
@@ -44,7 +43,12 @@ gh-tracker archives it before that happens.
 | **Commit Activity** | 52-week commit histogram by day-of-week | REST API |
 | **Code Frequency** | Weekly additions/deletions over time | REST API |
 | **Releases** | Per-asset download counts, sizes, dates | REST API |
+| **Workflow Runs** | GitHub Actions run history per repo | REST API |
+| **Security Alerts** | Dependabot / code-scanning alerts by severity | REST API |
+| **Branches** | Branch list with protection state | REST API |
 | **Community Health** | GitHub's health_percentage score | REST API |
+| **Enrichment** | OpenSSF scorecard, dependent repos, source rank | External |
+| **Mentions & Citations** | Social mentions and citations per repo | External |
 
 ## Dashboard Features
 
@@ -89,6 +93,7 @@ gh-tracker archives it before that happens.
                     ┌──────────▼──────────────┐
                     │   FastAPI (46 endpoints) │
                     │  async · Pydantic · CORS │
+                    │  serves built SPA at /   │
                     └──────────┬──────────────┘
                                │
                     ┌──────────▼──────────────┐
@@ -116,12 +121,34 @@ GH_TRACKER_PUBLIC_ONLY=true python collect_live.py
 # Start API server (defaults to port 50047 — override with GH_TRACKER_PORT)
 python run.py                            # → http://localhost:50047
 # GH_TRACKER_PORT=51234 python run.py    # pick your own port
+```
 
-# Frontend (separate terminal)
+### Two ways to run the frontend
+
+**Production — one process, one port.** Build the SPA once; the API serves it at `/`:
+
+```bash
 cd frontend
 npm install
-npm run dev   # → http://localhost:5173
+npm run build          # emits frontend/dist/
+# then start the backend — dashboard is at http://localhost:50047
 ```
+
+The API mounts `frontend/dist/` at `/` when that directory exists, so a single
+`run.py` process serves both the JSON API and the dashboard. `run.py` binds
+`0.0.0.0`, so the dashboard is reachable from other machines on your LAN at
+`http://<your-host-ip>:50047`.
+
+**Development — hot reload.** Run Vite alongside the backend:
+
+```bash
+cd frontend
+npm run dev            # → http://localhost:5173
+```
+
+The dev server proxies `/api` to `http://localhost:50047`, so the backend must be
+running too. If you override `GH_TRACKER_PORT`, update the proxy `target` in
+`frontend/vite.config.ts` to match.
 
 > **Port choice.** The API defaults to **50047** — picked from the ephemeral/50000+ range
 > so it won't collide with the usual suspects (8000/8080 dev servers, 3000 Node, 5000 Flask,
@@ -136,6 +163,11 @@ npm run dev   # → http://localhost:5173
 | `GH_TRACKER_PUBLIC_ONLY` | `false` | Only track public repos |
 | `GH_TRACKER_DB` | `data/metrics.db` | SQLite database path |
 | `GH_TRACKER_PORT` | `50047` | API server port (any valid TCP port) |
+| `GH_TRACKER_RUNNERS_CONFIG` | built-in defaults | Path to a JSON self-hosted runner config |
+| `GH_WEBHOOK_SECRET` | unset | Enables HMAC-SHA256 verification on `/api/webhooks/github` |
+
+> When `GH_WEBHOOK_SECRET` is unset, webhook signatures are **not** verified. Set it
+> before exposing `/api/webhooks/github` to anything other than localhost.
 
 ## Automated Collection
 
@@ -158,32 +190,99 @@ sudo systemctl enable --now gh-tracker-api.service
 
 ## API Endpoints
 
+Interactive OpenAPI docs are served at `/api/docs` while the server is running.
+
 <details>
-<summary>46 endpoints (click to expand)</summary>
+<summary>All 46 endpoints (click to expand)</summary>
+
+**Core**
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/health` | Health check |
+| GET | `/api/dashboard` | Cross-repo dashboard summary |
 | GET | `/api/repos` | List tracked repos |
-| GET | `/api/metadata` | All repos metadata |
-| GET | `/api/visitors` | Daily visitors (all repos) |
-| GET | `/api/visitors/summary` | Per-repo visitor aggregation |
+| POST | `/api/repos` | Add a repo to the tracked set |
+| DELETE | `/api/repos/{owner}/{repo}` | Remove a repo from the tracked set |
+
+**Traffic**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | GET | `/api/repos/{owner}/{repo}/traffic` | Daily traffic time series |
 | GET | `/api/repos/{owner}/{repo}/referrers` | Top referral sources |
 | GET | `/api/repos/{owner}/{repo}/paths` | Popular pages |
-| GET | `/api/repos/{owner}/{repo}/visitors` | Daily visitor drill-down |
 | GET | `/api/repos/{owner}/{repo}/summary` | Combined repo overview |
-| GET | `/api/repos/{owner}/{repo}/metadata` | Repo metadata |
+| GET | `/api/repos/{owner}/{repo}/visitors` | Daily visitor drill-down |
+| GET | `/api/visitors` | Daily visitors (all repos) |
+| GET | `/api/visitors/summary` | Per-repo visitor aggregation |
+| GET | `/api/repos/{owner}/{repo}/referrer-trends` | Referrers by date, appeared/disappeared |
+| GET | `/api/repos/{owner}/{repo}/bot-analysis` | Bot/automation traffic analysis |
+
+**People**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | GET | `/api/repos/{owner}/{repo}/stargazers` | Who starred |
 | GET | `/api/repos/{owner}/{repo}/watchers` | Who's watching |
 | GET | `/api/repos/{owner}/{repo}/forkers` | Who forked |
 | GET | `/api/repos/{owner}/{repo}/contributors` | Who committed |
 | GET | `/api/repos/{owner}/{repo}/people` | Combined people summary |
+| GET | `/api/repos/{owner}/{repo}/watcher-changes` | Watcher add/remove history |
+
+**Repo data**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/metadata` | All repos metadata |
+| GET | `/api/repos/{owner}/{repo}/metadata` | Repo metadata |
+| PATCH | `/api/repos/{owner}/{repo}/settings` | Proxy a repo settings update to GitHub |
 | GET | `/api/repos/{owner}/{repo}/issues/summary` | Issue/PR counts |
 | GET | `/api/repos/{owner}/{repo}/issues` | Issue list (filterable) |
+| GET | `/api/prs` | Open PRs across repos |
+| GET | `/api/repos/{owner}/{repo}/branches` | Branches with protection state |
 | GET | `/api/repos/{owner}/{repo}/commit-activity` | 52-week commit histogram |
 | GET | `/api/repos/{owner}/{repo}/code-frequency` | Weekly adds/deletes |
 | GET | `/api/repos/{owner}/{repo}/releases` | Release assets + downloads |
+| GET | `/api/repos/{owner}/{repo}/workflow-runs` | GitHub Actions run history |
+
+**Security**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/repos/{owner}/{repo}/security/alerts` | Alerts (filter by severity/type) |
+| GET | `/api/security/summary` | Alert counts across repos |
+
+**Signals**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/repos/{owner}/{repo}/mentions` | Social mentions for a repo |
+| GET | `/api/mentions/recent` | Recent mentions across repos |
+| GET | `/api/repos/{owner}/{repo}/citations` | Citations for a repo |
+| GET | `/api/citations/summary` | Citation counts across repos |
+| GET | `/api/repos/{owner}/{repo}/enrichment` | OpenSSF scorecard, dependents, rank |
+
+**Runners** (local probes, no webhooks)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/runners/state` | Current self-hosted runner states |
+| GET | `/api/runners/stream` | SSE stream of runner states |
+
+**Webhooks**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/webhooks/github` | Receive GitHub events (HMAC-SHA256 verified) |
+| GET | `/api/webhooks/events` | Last 100 webhook events |
+
+**Admin & export**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/admin/status` | Collection status |
+| GET | `/api/admin/backup` | Download the SQLite database |
 | GET | `/api/export/traffic` | Export traffic (CSV/JSON) |
 | GET | `/api/export/people` | Export people (CSV/JSON) |
 
@@ -192,7 +291,7 @@ sudo systemctl enable --now gh-tracker-api.service
 ## Development
 
 ```bash
-# Backend tests (252 passing)
+# Backend tests
 cd backend && pytest tests/ --ignore=tests/test_live_collect.py -v
 
 # Backend lint
@@ -213,15 +312,18 @@ backend/
     collector.py       # GitHub API data collection (REST + GraphQL)
     config.py          # Token/repo discovery via gh CLI
     database.py        # SQLite with 15 tables, async via aiosqlite
-    main.py            # FastAPI with 46 endpoints
+    main.py            # FastAPI with 46 endpoints + SPA static mount
     server_config.py   # Port resolution (GH_TRACKER_PORT, default 50047)
-  tests/               # 252 unit tests (pytest + pytest-httpx)
+    runner_probe.py    # Self-hosted runner process/log probing
+    runner_stuck.py    # Stuck-runner heuristics
+    runners_config.py  # Runner targets + thresholds
+  tests/               # pytest + pytest-httpx
   collect_live.py      # CLI entry point for data collection
-  run.py               # API server entry point
+  run.py               # API server entry point (binds 0.0.0.0)
 
 frontend/
   src/
-    components/     # 24 React components
+    components/     # React components
       KpiCard.tsx CommitHeatmap.tsx CodeFrequencyChart.tsx
       TrafficChart.tsx ReferrersChart.tsx PopularPaths.tsx
       VisitorsTable.tsx VisitorDrilldown.tsx PeoplePanel.tsx
@@ -229,6 +331,7 @@ frontend/
       RepoHeader.tsx
     App.tsx          # Main dashboard layout
     api.ts           # API client
+  dist/             # Production build, served by the API at /
 
 data/               # SQLite database (gitignored)
 ```


### PR DESCRIPTION
The README's endpoint reference listed **23 of 46** endpoints. The badge count was right; the table was half missing.

Verified every route against `backend/app/main.py` and rewrote the reference grouped by domain. Previously undocumented entirely:

- **Runners** — `/api/runners/state`, `/api/runners/stream` (SSE)
- **Webhooks** — `/api/webhooks/github`, `/api/webhooks/events`
- **Security** — `/api/repos/{owner}/{repo}/security/alerts`, `/api/security/summary`
- **Admin** — `/api/admin/status`, `/api/admin/backup`
- **Signals** — mentions, citations, enrichment
- **Repo management** — `POST /api/repos`, `DELETE /api/repos/{owner}/{repo}`, `PATCH .../settings`
- Plus `/api/dashboard`, `/api/prs`, `.../branches`, `.../workflow-runs`, `.../bot-analysis`, `.../watcher-changes`, `.../referrer-trends`

### Other corrections

- **Documents the single-port deployment.** `main.py` mounts `frontend/dist/` at `/`, so one `run.py` process serves both the JSON API and the dashboard. This was undocumented — the Quick Start only described the Vite dev server.
- **Documents the dev proxy**, and notes it must stay in sync with `GH_TRACKER_PORT`.
- **Adds two missing env vars** to the config table: `GH_TRACKER_RUNNERS_CONFIG` and `GH_WEBHOOK_SECRET`, with a warning that webhook signatures are **not verified** when the secret is unset (`main.py:299-300` fails open).
- **Python badge 3.12 → 3.11+**, matching `requires-python = ">=3.11"`.
- Notes `/api/docs` for interactive OpenAPI docs.

Docs only — no code changes.

Generated with Claude Code