### PR TITLE
fix(collector): paginate list endpoints and reconcile removals

### DIFF
--- a/backend/app/collector.py
+++ b/backend/app/collector.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime
 
 import httpx
@@ -18,6 +19,18 @@ GITHUB_API = "https://api.github.com"
 RATE_LIMIT_FLOOR = 50  # Stop making requests below this threshold
 MAX_RETRIES = 3
 RETRY_DELAY = 2.0  # seconds
+PER_PAGE = 100  # GitHub's maximum; default is 30
+MAX_PAGINATED_ITEMS = 10_000  # Backstop so one huge repo cannot exhaust the budget
+
+_LINK_NEXT_RE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
+
+
+def _next_page_url(link_header: str) -> str | None:
+    """Return the rel="next" URL from a Link header, or None when exhausted."""
+    if not link_header:
+        return None
+    match = _LINK_NEXT_RE.search(link_header)
+    return match.group(1) if match else None
 
 
 class RateLimitError(Exception):
@@ -164,50 +177,98 @@ class GitHubCollector:
         today = datetime.now(UTC).strftime("%Y-%m-%d")
         await self.db.store_paths(repo, today, data)
 
+    async def _paginate(
+        self, url: str, headers: dict | None = None
+    ) -> list[dict]:
+        """Fetch every page of a list endpoint.
+
+        GitHub returns 30 items per page by default and exposes the next page
+        through the Link header. Collecting only the first page silently
+        truncates stargazers, watchers, forkers and issues at 30.
+
+        Raises on HTTP errors so callers can distinguish "the repo really has
+        no members" from "the request failed" — reconciliation must never run
+        on a partial result.
+        """
+        items: list[dict] = []
+        separator = "&" if "?" in url else "?"
+        next_url: str | None = f"{url}{separator}per_page={PER_PAGE}"
+
+        while next_url:
+            self._check_rate_limit()
+            client = await self._get_client()
+            response = await client.get(next_url, headers=headers or {})
+            self._update_rate_limit(response)
+            response.raise_for_status()
+
+            page = response.json()
+            if not isinstance(page, list):
+                break
+            items.extend(page)
+
+            next_url = _next_page_url(response.headers.get("Link", ""))
+            if len(items) >= MAX_PAGINATED_ITEMS:
+                logger.warning(
+                    "Stopping pagination for %s at %d items (cap %d)",
+                    url, len(items), MAX_PAGINATED_ITEMS,
+                )
+                break
+
+        return items
+
     async def collect_stargazers(self, repo: str) -> None:
-        """Collect stargazers with timestamps."""
-        url = f"{GITHUB_API}/repos/{repo}/stargazers"
-        self._check_rate_limit()
-        client = await self._get_client()
-        # Need star+json accept header for timestamps
-        response = await client.get(
-            url,
+        """Collect stargazers with timestamps, then drop anyone who unstarred."""
+        # star+json accept header is what makes starred_at available.
+        stars = await self._paginate(
+            f"{GITHUB_API}/repos/{repo}/stargazers",
             headers={"Accept": "application/vnd.github.star+json"},
         )
-        self._update_rate_limit(response)
-        response.raise_for_status()
 
-        for star in response.json():
+        current: list[str] = []
+        for star in stars:
             user = star.get("user", {})
             username = user.get("login", "")
             starred_at = star.get("starred_at", "")
             if username:
                 await self.db.upsert_stargazer(repo, username, starred_at)
+                current.append(username)
+
+        removed = await self.db.reconcile_stargazers(repo, current)
+        if removed:
+            logger.info("Removed %d stale stargazer(s) for %s", removed, repo)
 
     async def collect_watchers(self, repo: str) -> None:
-        """Collect watchers (subscribers)."""
-        url = f"{GITHUB_API}/repos/{repo}/subscribers"
-        response = await self._request(url)
-        if response is None:
-            return
-        for user in response.json():
+        """Collect watchers (subscribers), then drop anyone who unwatched."""
+        users = await self._paginate(f"{GITHUB_API}/repos/{repo}/subscribers")
+
+        current: list[str] = []
+        for user in users:
             username = user.get("login", "")
             if username:
                 await self.db.upsert_watcher(repo, username)
+                current.append(username)
+
+        removed = await self.db.reconcile_watchers(repo, current)
+        if removed:
+            logger.info("Removed %d stale watcher(s) for %s", removed, repo)
 
     async def collect_forkers(self, repo: str) -> None:
-        """Collect forks with owner info."""
-        url = f"{GITHUB_API}/repos/{repo}/forks?sort=newest"
-        response = await self._request(url)
-        if response is None:
-            return
-        for fork in response.json():
+        """Collect forks with owner info, then drop deleted forks."""
+        forks = await self._paginate(f"{GITHUB_API}/repos/{repo}/forks?sort=newest")
+
+        current: list[str] = []
+        for fork in forks:
             owner = fork.get("owner", {})
             username = owner.get("login", "")
             fork_name = fork.get("full_name", "")
             forked_at = fork.get("created_at", "")
             if username:
                 await self.db.upsert_forker(repo, username, fork_name, forked_at)
+                current.append(username)
+
+        removed = await self.db.reconcile_forkers(repo, current)
+        if removed:
+            logger.info("Removed %d stale forker(s) for %s", removed, repo)
 
     async def collect_contributors(self, repo: str) -> None:
         """Collect contributors with commit stats."""
@@ -393,11 +454,9 @@ class GitHubCollector:
     async def collect_issues(self, repo: str) -> None:
         """Collect open and recently closed issues and PRs."""
         for state in ("open", "closed"):
-            url = f"{GITHUB_API}/repos/{repo}/issues?state={state}&per_page=30&sort=updated"
-            response = await self._request(url)
-            if response is None:
-                continue
-            for item in response.json():
+            url = f"{GITHUB_API}/repos/{repo}/issues?state={state}&sort=updated"
+            items = await self._paginate(url)
+            for item in items:
                 is_pr = "pull_request" in item
                 user = item.get("user", {})
                 label_names = ",".join(
@@ -592,15 +651,17 @@ class GitHubCollector:
             logger.warning("Could not collect Libraries.io data for %s", repo)
 
     async def detect_watcher_changes(self, repo: str) -> None:
-        """Compare current watchers on GitHub against the DB, storing additions/removals."""
-        url = f"{GITHUB_API}/repos/{repo}/subscribers"
-        response = await self._request(url)
-        if response is None:
-            return
+        """Compare current watchers on GitHub against the DB, storing additions/removals.
+
+        Must use the full paginated list. Diffing the stored watchers against a
+        single 30-item page reports everyone beyond the first page as "removed"
+        on every run, fabricating removal events that never happened.
+        """
+        users = await self._paginate(f"{GITHUB_API}/repos/{repo}/subscribers")
 
         current_usernames = {
             user.get("login", "")
-            for user in response.json()
+            for user in users
             if user.get("login")
         }
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -574,6 +574,49 @@ class Database:
         )
         return [dict(row) for row in await cursor.fetchall()]
 
+    async def _reconcile_usernames(
+        self, table: str, repo_name: str, current: list[str]
+    ) -> int:
+        """Delete rows for users no longer present upstream. Returns rows removed.
+
+        The collectors only ever INSERT, so without this anyone who unstars,
+        unwatches, or deletes a fork lingers forever and inflates every count
+        derived from these tables.
+
+        `current` must come from a complete, successful fetch — passing a
+        partial page would delete real rows. An empty list is meaningful and
+        legitimately clears the table for that repo.
+        """
+        if table not in {"stargazers", "watchers", "forkers"}:
+            raise ValueError(f"refusing to reconcile unknown table: {table}")
+
+        if current:
+            placeholders = ",".join("?" for _ in current)
+            sql = (
+                f"DELETE FROM {table} WHERE repo_name = ? "  # noqa: S608 - table is allow-listed above
+                f"AND username NOT IN ({placeholders})"
+            )
+            params: tuple = (repo_name, *current)
+        else:
+            sql = f"DELETE FROM {table} WHERE repo_name = ?"  # noqa: S608
+            params = (repo_name,)
+
+        cursor = await self._db.execute(sql, params)
+        await self._db.commit()
+        return cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+
+    async def reconcile_stargazers(self, repo_name: str, current: list[str]) -> int:
+        """Drop stored stargazers who no longer star the repo."""
+        return await self._reconcile_usernames("stargazers", repo_name, current)
+
+    async def reconcile_watchers(self, repo_name: str, current: list[str]) -> int:
+        """Drop stored watchers who no longer watch the repo."""
+        return await self._reconcile_usernames("watchers", repo_name, current)
+
+    async def reconcile_forkers(self, repo_name: str, current: list[str]) -> int:
+        """Drop stored forkers whose fork no longer exists."""
+        return await self._reconcile_usernames("forkers", repo_name, current)
+
     # --- People: Watchers ---
 
     async def upsert_watcher(self, repo_name: str, username: str) -> None:

--- a/backend/tests/test_collector.py
+++ b/backend/tests/test_collector.py
@@ -331,17 +331,17 @@ class TestMultiRepoCollection:
             )
             # People endpoints (4)
             httpx_mock.add_response(
-                url=f"https://api.github.com/repos/owner/{repo}/stargazers",
+                url=f"https://api.github.com/repos/owner/{repo}/stargazers?per_page=100",
                 json=[],
                 headers={"X-RateLimit-Remaining": "4986"},
             )
             httpx_mock.add_response(
-                url=f"https://api.github.com/repos/owner/{repo}/subscribers",
+                url=f"https://api.github.com/repos/owner/{repo}/subscribers?per_page=100",
                 json=[],
                 headers={"X-RateLimit-Remaining": "4985"},
             )
             httpx_mock.add_response(
-                url=f"https://api.github.com/repos/owner/{repo}/forks?sort=newest",
+                url=f"https://api.github.com/repos/owner/{repo}/forks?sort=newest&per_page=100",
                 json=[],
                 headers={"X-RateLimit-Remaining": "4984"},
             )
@@ -353,7 +353,7 @@ class TestMultiRepoCollection:
             # Issues endpoints (2: open + closed)
             for state in ("open", "closed"):
                 httpx_mock.add_response(
-                    url=f"https://api.github.com/repos/owner/{repo}/issues?state={state}&per_page=30&sort=updated",
+                    url=f"https://api.github.com/repos/owner/{repo}/issues?state={state}&sort=updated&per_page=100",
                     json=[],
                     headers={"X-RateLimit-Remaining": "4982"},
                 )

--- a/backend/tests/test_competitive_intel.py
+++ b/backend/tests/test_competitive_intel.py
@@ -9,7 +9,7 @@ Specs covered:
 6. Empty repo returns empty list for both endpoints
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -85,10 +85,10 @@ class TestDetectWatcherChanges:
         # DB has no watchers initially
 
         collector = GitHubCollector(token="tok", db=db, repos=[repo])
-        mock_response = MagicMock()
-        mock_response.json.return_value = [{"login": "alice"}]
 
-        with patch.object(collector, "_request", new=AsyncMock(return_value=mock_response)):
+        with patch.object(
+            collector, "_paginate", new=AsyncMock(return_value=[{"login": "alice"}])
+        ):
             await collector.detect_watcher_changes(repo)
 
         # alice should now be in watchers table
@@ -108,11 +108,11 @@ class TestDetectWatcherChanges:
         await db.upsert_watcher(repo, "bob")
 
         collector = GitHubCollector(token="tok", db=db, repos=[repo])
-        # GitHub now only returns alice — bob has un-watched
-        mock_response = MagicMock()
-        mock_response.json.return_value = [{"login": "alice"}]
 
-        with patch.object(collector, "_request", new=AsyncMock(return_value=mock_response)):
+        # GitHub now only returns alice — bob has un-watched
+        with patch.object(
+            collector, "_paginate", new=AsyncMock(return_value=[{"login": "alice"}])
+        ):
             await collector.detect_watcher_changes(repo)
 
         changes = await db.get_watcher_changes(repo)
@@ -126,10 +126,10 @@ class TestDetectWatcherChanges:
         await db.upsert_watcher(repo, "alice")
 
         collector = GitHubCollector(token="tok", db=db, repos=[repo])
-        mock_response = MagicMock()
-        mock_response.json.return_value = [{"login": "alice"}]
 
-        with patch.object(collector, "_request", new=AsyncMock(return_value=mock_response)):
+        with patch.object(
+            collector, "_paginate", new=AsyncMock(return_value=[{"login": "alice"}])
+        ):
             await collector.detect_watcher_changes(repo)
 
         changes = await db.get_watcher_changes(repo)
@@ -137,17 +137,25 @@ class TestDetectWatcherChanges:
 
         await collector.close()
 
-    async def test_none_response_is_handled_gracefully(self, db):
-        """If the API returns None (304/202), no crash and no changes stored."""
+    async def test_failed_fetch_records_no_changes(self, db):
+        """A failed fetch must not be read as "everyone left".
+
+        _paginate raises rather than returning a partial list, precisely so a
+        network or API failure cannot be mistaken for an empty watcher set and
+        turned into a pile of fabricated 'removed' events.
+        """
         repo = "owner/repo"
         await db.upsert_watcher(repo, "alice")
 
         collector = GitHubCollector(token="tok", db=db, repos=[repo])
-        with patch.object(collector, "_request", new=AsyncMock(return_value=None)):
-            await collector.detect_watcher_changes(repo)
+        with patch.object(
+            collector, "_paginate", new=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            with pytest.raises(RuntimeError):
+                await collector.detect_watcher_changes(repo)
 
-        changes = await db.get_watcher_changes(repo)
-        assert changes == []
+        assert await db.get_watcher_changes(repo) == []
+        assert len(await db.get_watchers(repo)) == 1
 
         await collector.close()
 

--- a/backend/tests/test_graphql_collector.py
+++ b/backend/tests/test_graphql_collector.py
@@ -189,17 +189,17 @@ class TestCollectGraphqlSummary:
         )
         # People
         httpx_mock.add_response(
-            url="https://api.github.com/repos/owner/myrepo/stargazers",
+            url="https://api.github.com/repos/owner/myrepo/stargazers?per_page=100",
             json=[],
             headers={"X-RateLimit-Remaining": "4995"},
         )
         httpx_mock.add_response(
-            url="https://api.github.com/repos/owner/myrepo/subscribers",
+            url="https://api.github.com/repos/owner/myrepo/subscribers?per_page=100",
             json=[],
             headers={"X-RateLimit-Remaining": "4994"},
         )
         httpx_mock.add_response(
-            url="https://api.github.com/repos/owner/myrepo/forks?sort=newest",
+            url="https://api.github.com/repos/owner/myrepo/forks?sort=newest&per_page=100",
             json=[],
             headers={"X-RateLimit-Remaining": "4993"},
         )
@@ -211,7 +211,7 @@ class TestCollectGraphqlSummary:
         # Issues
         for state in ("open", "closed"):
             httpx_mock.add_response(
-                url=f"https://api.github.com/repos/owner/myrepo/issues?state={state}&per_page=30&sort=updated",
+                url=f"https://api.github.com/repos/owner/myrepo/issues?state={state}&sort=updated&per_page=100",
                 json=[],
                 headers={"X-RateLimit-Remaining": "4991"},
             )

--- a/backend/tests/test_pagination_reconcile.py
+++ b/backend/tests/test_pagination_reconcile.py
@@ -1,0 +1,229 @@
+"""Tests for issue #37 — list endpoints must paginate, and must reconcile.
+
+Two defects, one root cause. The collectors fetched a single page (GitHub
+defaults to 30 items) and only ever INSERTed:
+
+1. Truncation. Any repo with more than 30 stargazers, watchers, forkers or
+   issues silently lost everyone past the first page.
+2. Staleness. Nobody was ever removed, so anyone who unstarred, unwatched or
+   deleted their fork lingered forever and inflated every derived count.
+
+The second bug also corrupted watcher history: detect_watcher_changes diffed
+the stored watchers against a single page, so on a repo with more than 30
+watchers it recorded everyone past page one as "removed" on *every* run.
+"""
+
+import pytest
+
+from app.collector import GitHubCollector, _next_page_url
+from app.database import Database
+
+API = "https://api.github.com"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test_paginate.db"))
+    await database.initialize()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def collector(db):
+    return GitHubCollector(token="test-token-fake", db=db, repos=["owner/repo"])
+
+
+def _link(url: str, rel: str = "next") -> str:
+    return f'<{url}>; rel="{rel}"'
+
+
+# --- Link header parsing ---------------------------------------------------
+
+
+class TestNextPageUrl:
+    def test_returns_none_for_empty_header(self):
+        assert _next_page_url("") is None
+
+    def test_returns_none_when_only_prev_and_last(self):
+        header = f'{_link("https://x/1", "prev")}, {_link("https://x/9", "last")}'
+        assert _next_page_url(header) is None
+
+    def test_extracts_next_url(self):
+        header = f'{_link("https://x/2")}, {_link("https://x/9", "last")}'
+        assert _next_page_url(header) == "https://x/2"
+
+    def test_extracts_next_when_not_first_in_header(self):
+        header = f'{_link("https://x/1", "prev")}, {_link("https://x/3")}'
+        assert _next_page_url(header) == "https://x/3"
+
+
+# --- Pagination ------------------------------------------------------------
+
+
+class TestPaginationNotTruncated:
+    async def test_stargazers_beyond_thirty_are_all_stored(self, collector, db, httpx_mock):
+        """A repo with 45 stargazers must yield 45 rows, not 30."""
+        page1 = [
+            {"user": {"login": f"user{i}"}, "starred_at": "2026-01-01T00:00:00Z"}
+            for i in range(30)
+        ]
+        page2 = [
+            {"user": {"login": f"user{i}"}, "starred_at": "2026-01-02T00:00:00Z"}
+            for i in range(30, 45)
+        ]
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/stargazers?per_page=100",
+            json=page1,
+            headers={"Link": _link(f"{API}/repos/owner/repo/stargazers?per_page=100&page=2")},
+        )
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/stargazers?per_page=100&page=2",
+            json=page2,
+        )
+
+        await collector.collect_stargazers("owner/repo")
+
+        stored = await db.get_stargazers("owner/repo")
+        assert len(stored) == 45
+        assert {s["username"] for s in stored} == {f"user{i}" for i in range(45)}
+
+    async def test_watchers_beyond_thirty_are_all_stored(self, collector, db, httpx_mock):
+        page1 = [{"login": f"w{i}"} for i in range(30)]
+        page2 = [{"login": f"w{i}"} for i in range(30, 40)]
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100",
+            json=page1,
+            headers={"Link": _link(f"{API}/repos/owner/repo/subscribers?per_page=100&page=2")},
+        )
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100&page=2",
+            json=page2,
+        )
+
+        await collector.collect_watchers("owner/repo")
+
+        assert len(await db.get_watchers("owner/repo")) == 40
+
+    async def test_requests_the_maximum_page_size(self, collector, db, httpx_mock):
+        """per_page=100 keeps the request count down on large repos."""
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100", json=[]
+        )
+        await collector.collect_watchers("owner/repo")
+        assert "per_page=100" in str(httpx_mock.get_requests()[0].url)
+
+
+# --- Reconciliation --------------------------------------------------------
+
+
+class TestReconciliation:
+    async def test_unstarred_user_is_removed(self, collector, db, httpx_mock):
+        """The bug that made the dashboard report 7 stars against GitHub's 4."""
+        await db.upsert_stargazer("owner/repo", "leaver", "2026-01-01T00:00:00Z")
+        await db.upsert_stargazer("owner/repo", "stayer", "2026-01-01T00:00:00Z")
+
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/stargazers?per_page=100",
+            json=[{"user": {"login": "stayer"}, "starred_at": "2026-01-01T00:00:00Z"}],
+        )
+
+        await collector.collect_stargazers("owner/repo")
+
+        assert {s["username"] for s in await db.get_stargazers("owner/repo")} == {"stayer"}
+
+    async def test_deleted_fork_is_removed(self, collector, db, httpx_mock):
+        await db.upsert_forker("owner/repo", "gone", "gone/repo", "2026-01-01T00:00:00Z")
+        await db.upsert_forker("owner/repo", "kept", "kept/repo", "2026-01-01T00:00:00Z")
+
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/forks?sort=newest&per_page=100",
+            json=[{
+                "owner": {"login": "kept"},
+                "full_name": "kept/repo",
+                "created_at": "2026-01-01T00:00:00Z",
+            }],
+        )
+
+        await collector.collect_forkers("owner/repo")
+
+        assert {f["username"] for f in await db.get_forkers("owner/repo")} == {"kept"}
+
+    async def test_empty_upstream_clears_the_repo(self, db):
+        """Zero members is a real state, not a fetch failure."""
+        await db.upsert_watcher("owner/repo", "someone")
+        removed = await db.reconcile_watchers("owner/repo", [])
+        assert removed == 1
+        assert await db.get_watchers("owner/repo") == []
+
+    async def test_other_repos_are_untouched(self, db):
+        await db.upsert_stargazer("owner/repo", "alice", "")
+        await db.upsert_stargazer("other/repo", "alice", "")
+
+        await db.reconcile_stargazers("owner/repo", [])
+
+        assert await db.get_stargazers("owner/repo") == []
+        assert len(await db.get_stargazers("other/repo")) == 1
+
+    async def test_failed_fetch_does_not_delete_anything(self, collector, db, httpx_mock):
+        """A partial or failed fetch must never be treated as ground truth."""
+        await db.upsert_stargazer("owner/repo", "alice", "")
+        await db.upsert_stargazer("owner/repo", "bob", "")
+
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/stargazers?per_page=100", status_code=500
+        )
+
+        with pytest.raises(Exception):
+            await collector.collect_stargazers("owner/repo")
+
+        assert len(await db.get_stargazers("owner/repo")) == 2
+
+    async def test_refuses_unknown_table(self, db):
+        with pytest.raises(ValueError, match="unknown table"):
+            await db._reconcile_usernames("repo_metadata", "owner/repo", [])
+
+
+# --- Watcher-change fabrication --------------------------------------------
+
+
+class TestWatcherChangesNotFabricated:
+    async def test_no_removals_when_watchers_span_two_pages(
+        self, collector, db, httpx_mock
+    ):
+        """35 unchanged watchers must produce zero 'removed' events."""
+        watchers = [f"w{i}" for i in range(35)]
+        for name in watchers:
+            await db.upsert_watcher("owner/repo", name)
+
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100",
+            json=[{"login": n} for n in watchers[:30]],
+            headers={"Link": _link(f"{API}/repos/owner/repo/subscribers?per_page=100&page=2")},
+        )
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100&page=2",
+            json=[{"login": n} for n in watchers[30:]],
+        )
+
+        await collector.detect_watcher_changes("owner/repo")
+
+        changes = await db.get_watcher_changes("owner/repo")
+        assert [c for c in changes if c["action"] == "removed"] == []
+
+    async def test_genuine_removal_is_still_recorded(self, collector, db, httpx_mock):
+        await db.upsert_watcher("owner/repo", "stayer")
+        await db.upsert_watcher("owner/repo", "leaver")
+
+        httpx_mock.add_response(
+            url=f"{API}/repos/owner/repo/subscribers?per_page=100",
+            json=[{"login": "stayer"}],
+        )
+
+        await collector.detect_watcher_changes("owner/repo")
+
+        removed = [
+            c for c in await db.get_watcher_changes("owner/repo")
+            if c["action"] == "removed"
+        ]
+        assert [c["username"] for c in removed] == ["leaver"]


### PR DESCRIPTION
Closes #37.

GitHub returns 30 items per page by default. collect_stargazers,
collect_watchers, collect_forkers and collect_issues each read only the
first page, so every repo with more than 30 of anything silently lost the
remainder. collect_issues asked for per_page=30 explicitly.

Add _paginate(), which follows the Link rel="next" header at per_page=100
until exhausted, with a 10k backstop so one very large repo cannot consume
the whole rate-limit budget.

Reconcile, not just insert

Pagination alone does not fix the counts. These collectors only ever
INSERTed, and the sole delete path was a star/deleted webhook that is not
configured, so anyone who unstarred, unwatched or deleted a fork stayed in
the database permanently. On live data this is what made the dashboard
report 7 stars where GitHub reports 4.

Each collector now passes the full upstream set to a reconcile_* method
that removes rows for anyone no longer present.

_paginate raises rather than returning a partial list. That distinction
matters: reconciliation treats its input as ground truth, so a failed or
partial fetch must never reach it and be read as "everyone left". An empty
list is a legitimate state and does clear the repo.

detect_watcher_changes

Same root cause, worse symptom. It diffed the stored watchers against a
single 30-item page, so on a repo with more than 30 watchers it recorded
everyone past page one as "removed" on every single run, fabricating
removal events that never happened. It now diffs against the full list.

Tests

- 15 new tests in test_pagination_reconcile.py: Link-header parsing,
  multi-page collection, removal of unstarred users and deleted forks,
  repo isolation, empty-upstream clearing, rejection of unknown tables,
  no deletion on a failed fetch, and no fabricated watcher removals across
  a page boundary.
- Existing collector tests updated: their mocked URLs pinned the old
  single-page requests. test_none_response_is_handled_gracefully is
  replaced by test_failed_fetch_records_no_changes, matching the new
  raise-on-failure contract.

274 backend tests passing, ruff clean.

Co-Authored-By: Claude <noreply@anthropic.com>

Generated with Claude Code