### PR TITLE
feat(runners): find runners.json without environment plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,36 @@ running too. If you override `GH_TRACKER_PORT`, update the proxy `target` in
 | `GH_TRACKER_PUBLIC_ONLY` | `false` | Only track public repos |
 | `GH_TRACKER_DB` | `data/metrics.db` | SQLite database path |
 | `GH_TRACKER_PORT` | `50047` | API server port (any valid TCP port) |
-| `GH_TRACKER_RUNNERS_CONFIG` | built-in defaults | Path to a JSON self-hosted runner config |
+| `GH_TRACKER_RUNNERS_CONFIG` | `runners.json` | Path to a JSON self-hosted runner config |
 | `GH_WEBHOOK_SECRET` | unset | Enables HMAC-SHA256 verification on `/api/webhooks/github` |
 
 > When `GH_WEBHOOK_SECRET` is unset, webhook signatures are **not** verified. Set it
 > before exposing `/api/webhooks/github` to anything other than localhost.
+
+### Self-hosted runner config
+
+Runner targets name your own machines, so they are not committed. Drop a
+`runners.json` in the repository root and the runner pane picks it up with no
+further setup — `GH_TRACKER_RUNNERS_CONFIG` only exists to point somewhere else.
+With no file present the pane reports no runners.
+
+```json
+{
+  "pollIntervalMs": 2000,
+  "stuck": { "workerAgeMinutes": 20, "logSilenceSeconds": 90, "lowCpuPercent": 2 },
+  "runners": [
+    { "name": "my-local-runner", "kind": "local",
+      "runnerDir": "/opt/actions-runner",
+      "service": "actions.runner.<org>.<name>.service" },
+    { "name": "my-remote-runner", "kind": "ssh", "sshHost": "buildbox",
+      "runnerDir": "/home/<user>/actions-runner",
+      "service": "actions.runner.<org>.<name>.service" }
+  ]
+}
+```
+
+`name` should match the GitHub-registered runner name exactly. `runners.json` is
+gitignored.
 
 ## Automated Collection
 

--- a/backend/app/runners_config.py
+++ b/backend/app/runners_config.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -87,11 +90,32 @@ def _from_dict(d: dict) -> RunnersConfig:
     )
 
 
+# Checked when GH_TRACKER_RUNNERS_CONFIG is unset, so a native deployment only
+# has to drop the file next to the code — no environment plumbing, no unit-file
+# edit. Gitignored, since its contents are operator-specific.
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "runners.json"
+
+
 def load_config() -> RunnersConfig:
-    path = os.environ.get("GH_TRACKER_RUNNERS_CONFIG")
-    if path and Path(path).is_file():
+    """Load runner targets from the first config file that exists.
+
+    Order: GH_TRACKER_RUNNERS_CONFIG, then <repo>/runners.json. A malformed file
+    is skipped rather than fatal — a broken runner pane must not stop the API
+    from serving analytics.
+    """
+    candidates: list[Path] = []
+
+    env_path = os.environ.get("GH_TRACKER_RUNNERS_CONFIG")
+    if env_path:
+        candidates.append(Path(env_path))
+    candidates.append(DEFAULT_CONFIG_PATH)
+
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
         try:
-            return _from_dict(json.loads(Path(path).read_text()))
-        except Exception:
-            pass
+            return _from_dict(json.loads(candidate.read_text()))
+        except (OSError, ValueError, KeyError, TypeError):
+            logger.warning("Ignoring unreadable runner config at %s", candidate)
+
     return RunnersConfig(runners=DEFAULT_RUNNERS, rules=StuckRules())

--- a/backend/tests/test_runners_config.py
+++ b/backend/tests/test_runners_config.py
@@ -1,0 +1,120 @@
+"""Tests for runner-target configuration resolution.
+
+Runner targets describe the operator's own machines — hostnames, filesystem
+paths, systemd unit names — so they are configuration rather than code and are
+not committed. The loader therefore has to find them reliably, and degrade to
+"no runners" rather than crashing when it cannot.
+"""
+
+import json
+
+import pytest
+
+from app import runners_config
+from app.runners_config import RunnerTarget, load_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("GH_TRACKER_RUNNERS_CONFIG", raising=False)
+
+
+def _write(path, runners, **top):
+    payload = {"runners": runners, **top}
+    path.write_text(json.dumps(payload))
+    return path
+
+
+SAMPLE = [{
+    "name": "box-a",
+    "kind": "ssh",
+    "sshHost": "buildbox",
+    "runnerDir": "/home/someone/actions-runner",
+    "service": "actions.runner.org.box-a.service",
+}]
+
+
+class TestNoConfiguration:
+    def test_ships_with_no_runners(self, monkeypatch, tmp_path):
+        """The repository must not carry anyone's runner topology."""
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", tmp_path / "absent.json")
+        assert load_config().runners == []
+
+    def test_default_runners_constant_is_empty(self):
+        assert runners_config.DEFAULT_RUNNERS == []
+
+
+class TestDefaultPath:
+    def test_loads_runners_json_beside_the_repo(self, monkeypatch, tmp_path):
+        """A native deploy only has to drop the file — no env var, no unit edit."""
+        cfg_file = _write(tmp_path / "runners.json", SAMPLE, pollIntervalMs=1500)
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", cfg_file)
+
+        cfg = load_config()
+
+        assert [r.name for r in cfg.runners] == ["box-a"]
+        assert cfg.runners[0].ssh_host == "buildbox"
+        assert cfg.poll_interval_ms == 1500
+
+    def test_env_var_takes_precedence(self, monkeypatch, tmp_path):
+        default_file = _write(tmp_path / "runners.json", [dict(SAMPLE[0], name="from-default")])
+        env_file = _write(tmp_path / "override.json", [dict(SAMPLE[0], name="from-env")])
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", default_file)
+        monkeypatch.setenv("GH_TRACKER_RUNNERS_CONFIG", str(env_file))
+
+        assert [r.name for r in load_config().runners] == ["from-env"]
+
+    def test_falls_back_when_env_path_is_missing(self, monkeypatch, tmp_path):
+        """A stale env var must not mask a perfectly good default file."""
+        default_file = _write(tmp_path / "runners.json", SAMPLE)
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", default_file)
+        monkeypatch.setenv("GH_TRACKER_RUNNERS_CONFIG", str(tmp_path / "nope.json"))
+
+        assert [r.name for r in load_config().runners] == ["box-a"]
+
+
+class TestMalformedConfig:
+    def test_invalid_json_degrades_to_no_runners(self, monkeypatch, tmp_path):
+        """A broken runner pane must not take the analytics API down with it."""
+        bad = tmp_path / "runners.json"
+        bad.write_text("{ this is not json")
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", bad)
+
+        assert load_config().runners == []
+
+    def test_missing_required_key_degrades_to_no_runners(self, monkeypatch, tmp_path):
+        bad = _write(tmp_path / "runners.json", [{"name": "x", "kind": "local"}])  # no runnerDir
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", bad)
+
+        assert load_config().runners == []
+
+
+class TestStuckRules:
+    def test_thresholds_are_read_from_file(self, monkeypatch, tmp_path):
+        cfg_file = _write(
+            tmp_path / "runners.json", SAMPLE,
+            stuck={"workerAgeMinutes": 5, "logSilenceSeconds": 15, "lowCpuPercent": 1},
+        )
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", cfg_file)
+
+        rules = load_config().rules
+        assert (rules.worker_age_minutes, rules.log_silence_seconds, rules.low_cpu_percent) == (
+            5.0, 15.0, 1.0,
+        )
+
+    def test_thresholds_have_defaults(self, monkeypatch, tmp_path):
+        cfg_file = _write(tmp_path / "runners.json", SAMPLE)
+        monkeypatch.setattr(runners_config, "DEFAULT_CONFIG_PATH", cfg_file)
+
+        rules = load_config().rules
+        assert (rules.worker_age_minutes, rules.log_silence_seconds, rules.low_cpu_percent) == (
+            20.0, 90.0, 2.0,
+        )
+
+
+class TestRunnerTarget:
+    def test_is_immutable(self):
+        """Targets are shared across concurrent probes; they must not be mutated."""
+        target = RunnerTarget(name="a", kind="local", runner_dir="/tmp")
+        with pytest.raises(Exception):
+            target.name = "b"


### PR DESCRIPTION
Runner targets were made repo-free in #40 so operator hostnames, paths and
systemd unit names would stop being committed. That left GH_TRACKER_RUNNERS_CONFIG
as the only way to supply them, which on a native systemd deployment means
editing a unit file as root to enable a feature that is otherwise pure config.

load_config() now falls back to <repo>/runners.json when the environment
variable is unset. Dropping the file next to the code is enough; the variable
remains for pointing elsewhere and still takes precedence. A stale environment
path no longer masks a perfectly good default file — a missing candidate is
skipped rather than treated as final.

A malformed config is logged and skipped rather than raised. The runner pane is
a convenience; it must not stop the API from serving analytics.

Adds test_runners_config.py (10 tests): shipping with no runner topology,
default-path discovery, environment precedence, fallback past a missing
environment path, degradation on invalid JSON and on missing required keys,
threshold parsing and defaults, and immutability of RunnerTarget.

README documents the default path and the file format.

Co-Authored-By: Claude <noreply@anthropic.com>

Generated with Claude Code